### PR TITLE
Export 444 for Host based connections

### DIFF
--- a/templates/vault_tenant.conf.j2
+++ b/templates/vault_tenant.conf.j2
@@ -29,3 +29,31 @@ server {
       proxy_read_timeout      90;
     }
 }
+
+server {
+    listen              444 ssl proxy_protocol;
+    server_name         {{ item | basename }};
+    ssl_certificate     {{ ssl_router_nginx_config_dir }}{{ item | basename }}.cert;
+    ssl_certificate_key {{ ssl_router_nginx_config_dir }}{{ item | basename }}.cert;
+    ssl_protocols       TLSv1.1 TLSv1.2;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+
+    set_real_ip_from {{ ansible_default_ipv4.network | ipsubnet(16,0) }};
+    real_ip_header proxy_protocol;
+    real_ip_recursive on;
+
+    access_log /var/log/nginx/access.log elb_log;
+
+    location / {
+      proxy_set_header        Via terminator;
+      proxy_set_header        Host $host;
+      proxy_set_header        X-Real-IP $proxy_protocol_addr;
+      proxy_set_header        X-Forwarded-For $proxy_protocol_addr;
+      proxy_set_header        X-Forwarded-Proto $scheme;
+      proxy_set_header        VGS-Tenant {{ item.split('/')[-2].split('.')[0] }};
+      resolver                {{ ansible_dns.nameservers | join (',') }};
+      set                     $vault                                          https://{{ item.split('/')[-2] }};
+      proxy_pass              $vault;
+      proxy_read_timeout      90;
+    }
+}


### PR DESCRIPTION
**DO NOT MERGE**

Experiment with having host based proxying exposed on port 444.

This will forward the host header to the upstream proxy which will then use that to look up from the rules for the tenant. This can potentially enable multiple reverse proxies.

However, if we want to support this seamlessly for customers we still need to find a way to make this easily work with their rules.

https://app.clubhouse.io/vgs/story/2263/shift-ledge-have-two-different-reverse-proxies-in-one-live-vault