### PR TITLE
All Requests Via NGINX

### DIFF
--- a/templates/verygoodproxy.conf.j2
+++ b/templates/verygoodproxy.conf.j2
@@ -14,6 +14,30 @@ server {
 }
 
 server {
+    listen              80;
+    server_name         ~^(?<tenant>.+)\.(?<environment>(live|sandbox))\.verygoodproxy\.(?<tld>(io|com))$;
+
+    set_real_ip_from {{ ansible_default_ipv4.network | ipsubnet(16,0) }};
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+
+    access_log /var/log/nginx/access.log elb_log;
+
+    location / {
+      proxy_set_header        Host reverse.$environment.verygoodproxy.com;
+      proxy_set_header        Via terminator;
+      proxy_set_header        X-Forwarded-Host $host;
+      proxy_set_header        X-Real-IP $remote_addr;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header        VGS-Tenant $tenant;
+      resolver                {{ ansible_dns.nameservers | join (',') }};
+      set                     $vault                                          https://reverse.$environment.verygoodproxy.com;
+      proxy_pass              $vault;
+      proxy_read_timeout      90;
+    }
+}
+
+server {
     listen              80 default_server;
     server_name         _;    
 


### PR DESCRIPTION
**Experiment. DO NOT MERGE**

Allows forwarding all requests via NGINX by providing the proxy with a special CNAME `reverse.$environment.verygoodproxy.com`

This special CNAME needs to be sent to the proxies and then all other tenants can be sent via NGINX.