### PR TITLE
Add Support for Pass-Through Hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/*
+provision-certificates.retry

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ ssl_router_nginx_config_dir: /etc/nginx/sites-available/
 ssl_router_nginx_enabled_dir: /etc/nginx/sites-enabled/
 # ssl_router_nginx_config_dir: /tmp/available/
 # ssl_router_nginx_enabled_dir: /tmp/enabled/
+dns_resolver: "{{ ansible_dns.nameservers | join (',') }}"
 
 cert_mgr_url: http://certificates.verygoodsecurity.io
 ssl_router_tld: verygoodproxy.io

--- a/migrate.py
+++ b/migrate.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+import argparse
+import boto3
+
+
+PREFIX = 'ssl'
+
+
+def main(args):
+    client = boto3.client('s3')
+    response = client.list_objects(Bucket=args.bucket, Prefix=PREFIX + '/')
+
+    for f in response['Contents']:
+        src = f['Key']
+        dest = rename(src)
+        if not args.dry_run and dest:
+            copy(src, dest, client, args.bucket)
+        else:
+            print(src, dest)
+
+
+def copy(src, dest, client, bucket):
+    copy_source = {
+        'Bucket': bucket,
+        'Key': src
+    }
+    extra_args = {
+        'ServerSideEncryption': 'AES256'
+    }
+    result = client.copy(copy_source, bucket, dest, extra_args)
+    print(result)
+
+
+def rename(key):
+    try:
+        _, upstream, host = key.split('/')
+    except:
+        print('ERROR: ' + key)
+        return
+    parts = (
+        # prefix
+        PREFIX,
+        # version
+        '2',
+        # no passthrough
+        'np',
+        # static upstream
+        upstream.replace(upstream.split('.')[0], 'reverse'),
+        # data environment
+        'sandbox' if 'sandbox' in upstream else 'live',
+        # tenant id
+        upstream.split('.')[0],
+        # custom host name
+        host
+    )
+    return '/'.join(parts)
+
+
+if __name__ == '__main__':
+    parser  = argparse.ArgumentParser()
+    parser.add_argument('bucket')
+    parser.add_argument('--dry-run', dest='dry_run', action='store_true')
+    parser.add_argument('--no-dry-run', dest='dry_run', action='store_false')
+    parser.set_defaults(dry_run=True)
+
+    main(parser.parse_args())

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,7 @@
 - name: add tenant configs
   template: src=templates/vault_tenant.conf.j2 dest={{ ssl_router_nginx_config_dir }}{{ item | basename }}.config mode=0400
   with_items: "{{ ssl_domains.s3_keys }}"
+  when: item.startswith('ssl/2/') | bool
 
 - name: symlink to available
   file: src={{ ssl_router_nginx_config_dir }}{{ item | basename }}.config dest={{ ssl_router_nginx_enabled_dir }}{{ item | basename }}.config state=link

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -41,6 +41,9 @@ http {
       '"time": "$time_local", '
       '"remote_addr": "$proxy_protocol_addr", '
       '"remote_user": "$remote_user", '
+      '"tenant": "$tenant", '
+      '"data_environment": "$data_environment", '
+      '"tenant_endpoint": "$tenant_endpoint", '
       '"request": "$request", '
       '"status": $status, '
       '"body_bytes_sent": $body_bytes_sent, '
@@ -91,10 +94,12 @@ stream {
       server forward.sandbox.{{ ssl_router_tld }}:8080 backup;
     }
     server {
+      #set $data_environment live;  # Doesn't work :(
       listen     8080;
       proxy_pass live_forward_proxies;
     }
     server {
+      #set $data_environment sandbox;
       listen     8081;
       proxy_pass sandbox_forward_proxies;
     }

--- a/templates/vault_tenant.conf.j2
+++ b/templates/vault_tenant.conf.j2
@@ -1,35 +1,45 @@
 # {{ ansible_managed }}
 # This template represents a termination point for a SSL certificate
 
+{% set url_parts = item.split('/') %}
+{% set proxy_address = url_parts[-2] %}
+{% set custom_host_name = url_parts[-1] %}
+{% set passthrough_host_name = url_parts[1] == 'pt' %}
+
+{% if proxy_address.split('.') | length > 1 %}
+
+{% set data_environment = proxy_address.split('.')[1] %}
+{% set tenant = proxy_address.split('.')[0] %}
+
 server {
+
     listen              443 ssl proxy_protocol;
-    server_name         {{ item | basename }};
-    ssl_certificate     {{ ssl_router_nginx_config_dir }}{{ item | basename }}.cert;
-    ssl_certificate_key {{ ssl_router_nginx_config_dir }}{{ item | basename }}.cert;
+    server_name         {{ custom_host_name }};
+    ssl_certificate     /etc/nginx/conf.d/{{ custom_host_name }}.cert;
+    ssl_certificate_key /etc/nginx/conf.d/{{ custom_host_name }}.cert;
     ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers         HIGH:!aNULL:!MD5;
 
-    set_real_ip_from {{ ansible_default_ipv4.network | ipsubnet(16,0) }};
+    set_real_ip_from 0.0.0.0/0;
     real_ip_header proxy_protocol;
     real_ip_recursive on;
 
-    access_log /var/log/nginx/access.log elb_log;
+    access_log /dev/stdout elb_log;
 
-    {% if item.split('/')[-2].split('.') | length > 1 %}
     location / {
-      proxy_set_header        Host reverse.{{ item.split('/')[-2].split('.')[1] }}.{{ ssl_router_tld }};
+      proxy_set_header        Host {% if passthrough_host_name %}$host{% else %}reverse.{{ data_environment }}.{{ ssl_router_tld }}{% endif %};
       proxy_set_header        Via terminator;
       proxy_set_header        X-Forwarded-Host $host;
       proxy_set_header        X-Real-IP $proxy_protocol_addr;
       proxy_set_header        X-Forwarded-For $proxy_protocol_addr;
       proxy_set_header        X-Forwarded-Proto $scheme;
-      proxy_set_header        VGS-Tenant {{ item.split('/')[-2].split('.')[0] }};
+      proxy_set_header        VGS-Tenant {{ tenant }};
       resolver                {{ ansible_dns.nameservers | join (',') }};
-      
-      set                     $vault                                          https://reverse.{{ item.split('/')[-2].split('.')[1] }}.{{ ssl_router_tld }};
+
+      set                     $vault    https://reverse.{{ data_environment }}.{{ ssl_router_tld }};
       proxy_pass              $vault;
-      
       proxy_read_timeout      90;
     }
-    {% endif %}
 }
+
+{% endif %}

--- a/templates/vault_tenant.conf.j2
+++ b/templates/vault_tenant.conf.j2
@@ -15,16 +15,16 @@ server {
 
     listen              443 ssl proxy_protocol;
     server_name         {{ custom_host_name }};
-    ssl_certificate     /etc/nginx/conf.d/{{ custom_host_name }}.cert;
-    ssl_certificate_key /etc/nginx/conf.d/{{ custom_host_name }}.cert;
+    ssl_certificate     {{ ssl_router_nginx_config_dir }}{{ custom_host_name }}.cert;
+    ssl_certificate_key {{ ssl_router_nginx_config_dir }}{{ custom_host_name }}.cert;
     ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers         HIGH:!aNULL:!MD5;
 
-    set_real_ip_from 0.0.0.0/0;
+    set_real_ip_from {{ ansible_default_ipv4.network | ipsubnet(16,0) }};
     real_ip_header proxy_protocol;
     real_ip_recursive on;
 
-    access_log /dev/stdout elb_log;
+    access_log /var/log/nginx/access.log elb_log;
 
     location / {
       proxy_set_header        Host {% if passthrough_host_name %}$host{% else %}reverse.{{ data_environment }}.{{ ssl_router_tld }}{% endif %};

--- a/templates/vault_tenant.conf.j2
+++ b/templates/vault_tenant.conf.j2
@@ -13,8 +13,8 @@ server {
 
     listen              443 ssl proxy_protocol;
     server_name         {{ custom_host_name }};
-    ssl_certificate     /etc/nginx/conf.d/{{ custom_host_name }}.cert;
-    ssl_certificate_key /etc/nginx/conf.d/{{ custom_host_name }}.cert;
+    ssl_certificate     {{ ssl_router_nginx_config_dir }}{{ custom_host_name }}.cert;
+    ssl_certificate_key {{ ssl_router_nginx_config_dir }}{{ custom_host_name }}.cert;
     ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers         HIGH:!aNULL:!MD5;
 

--- a/templates/vault_tenant.conf.j2
+++ b/templates/vault_tenant.conf.j2
@@ -5,11 +5,12 @@
 {% set proxy_address = url_parts[-2] %}
 {% set custom_host_name = url_parts[-1] %}
 {% set passthrough_host_name = url_parts[1] == 'pt' %}
+{% set proxy_parts = proxy_address.split('.') %}
 
-{% if proxy_address.split('.') | length > 1 %}
+{% if proxy_parts | length > 1 %}
 
-{% set data_environment = proxy_address.split('.')[1] %}
-{% set tenant = proxy_address.split('.')[0] %}
+{% set tenant = proxy_parts[0] %}
+{% set data_environment = proxy_address.split(ssl_router_tld)[0].split('.')[-2] %}
 
 server {
 

--- a/templates/vault_tenant.conf.j2
+++ b/templates/vault_tenant.conf.j2
@@ -30,7 +30,7 @@ server {
       proxy_set_header        X-Forwarded-For $proxy_protocol_addr;
       proxy_set_header        X-Forwarded-Proto $scheme;
       proxy_set_header        VGS-Tenant {{ tenant }};
-      resolver                {{ dns_resolver }};
+      resolver                {{ ansible_dns.nameservers | join (',') }};
 
       set                     $vault    https://{{ upstream_name }};
       proxy_pass              $vault;

--- a/templates/vault_tenant.conf.j2
+++ b/templates/vault_tenant.conf.j2
@@ -30,7 +30,7 @@ server {
       proxy_set_header        X-Forwarded-For $proxy_protocol_addr;
       proxy_set_header        X-Forwarded-Proto $scheme;
       proxy_set_header        VGS-Tenant {{ tenant }};
-      resolver                {{ ansible_dns.nameservers | join (',') }};
+      resolver                {{ dns_resolver }};
 
       set                     $vault    https://{{ upstream_name }};
       proxy_pass              $vault;

--- a/templates/vault_tenant.conf.j2
+++ b/templates/vault_tenant.conf.j2
@@ -38,6 +38,12 @@ server {
       proxy_pass              $vault;
       proxy_read_timeout      90;
     }
+
+    set $tenant {{ tenant }};
+    set $data_environment {{ data_environment }};
+    set $tenant_endpoint $http_host;
+    access_log /var/log/nginx/access.log json_combined;
+
 }
 
 {% endif %}

--- a/templates/vault_tenant.conf.j2
+++ b/templates/vault_tenant.conf.j2
@@ -2,40 +2,37 @@
 # This template represents a termination point for a SSL certificate
 
 {% set url_parts = item.split('/') %}
-{% set proxy_address = url_parts[-2] %}
-{% set custom_host_name = url_parts[-1] %}
-{% set passthrough_host_name = url_parts[1] == 'pt' %}
-{% set proxy_parts = proxy_address.split('.') %}
 
-{% if proxy_parts | length > 1 %}
-
-{% set tenant = proxy_parts[0] %}
-{% set data_environment = proxy_address.split(ssl_router_tld)[0].split('.')[-2] %}
+{% set passthrough_host_name = url_parts[2] == 'pt' %}
+{% set upstream_name = url_parts[3] %}
+{% set data_environment = url_parts[4] %}
+{% set tenant = url_parts[5] %}
+{% set custom_host_name = url_parts[6] %}
 
 server {
 
     listen              443 ssl proxy_protocol;
     server_name         {{ custom_host_name }};
-    ssl_certificate     {{ ssl_router_nginx_config_dir }}{{ custom_host_name }}.cert;
-    ssl_certificate_key {{ ssl_router_nginx_config_dir }}{{ custom_host_name }}.cert;
+    ssl_certificate     /etc/nginx/conf.d/{{ custom_host_name }}.cert;
+    ssl_certificate_key /etc/nginx/conf.d/{{ custom_host_name }}.cert;
     ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers         HIGH:!aNULL:!MD5;
 
-    set_real_ip_from {{ ansible_default_ipv4.network | ipsubnet(16,0) }};
+    set_real_ip_from 0.0.0.0/0;
     real_ip_header proxy_protocol;
     real_ip_recursive on;
 
     location / {
-      proxy_set_header        Host {% if passthrough_host_name %}$host{% else %}reverse.{{ data_environment }}.{{ ssl_router_tld }}{% endif %};
+      proxy_set_header        Host {% if passthrough_host_name %}$host{% else %}{{ upstream_name }}{% endif %};
       proxy_set_header        Via terminator;
       proxy_set_header        X-Forwarded-Host $host;
       proxy_set_header        X-Real-IP $proxy_protocol_addr;
       proxy_set_header        X-Forwarded-For $proxy_protocol_addr;
       proxy_set_header        X-Forwarded-Proto $scheme;
       proxy_set_header        VGS-Tenant {{ tenant }};
-      resolver                {{ ansible_dns.nameservers | join (',') }};
+      resolver                {{ dns_resolver }};
 
-      set                     $vault    https://reverse.{{ data_environment }}.{{ ssl_router_tld }};
+      set                     $vault    https://{{ upstream_name }};
       proxy_pass              $vault;
       proxy_read_timeout      90;
     }
@@ -46,5 +43,3 @@ server {
     access_log /var/log/nginx/access.log json_combined;
 
 }
-
-{% endif %}

--- a/templates/verygoodproxy.conf.j2
+++ b/templates/verygoodproxy.conf.j2
@@ -2,7 +2,7 @@ server {
     listen              443 ssl default_server;
     server_name         _;
     ssl_certificate     {{ ssl_router_nginx_config_dir }}verygoodproxy.cert;
-    ssl_certificate_key {{ ssl_router_nginx_config_dir }}verygoodproxy.cert;    
+    ssl_certificate_key {{ ssl_router_nginx_config_dir }}verygoodproxy.cert;
     ssl_protocols       TLSv1.2;
     ssl_ciphers         HIGH:!aNULL:!MD5;
 
@@ -15,29 +15,32 @@ server {
 
 server {
     listen              80;
-    server_name         ~^(?<tenant>.+)\.(?<environment>(live|sandbox))\.verygoodproxy\.(?<tld>(io|com))$;
+    server_name         ~^(?<tenant>.+)\.(?<data_environment>(live|sandbox))\.verygoodproxy\.(?<tld>(io|com))$;
 
     set_real_ip_from {{ ansible_default_ipv4.network | ipsubnet(16,0) }};
     real_ip_header X-Forwarded-For;
     real_ip_recursive on;
 
     location / {
-      proxy_set_header        Host $tenant.$environment.verygoodproxy.$tld;
+      proxy_set_header        Host $tenant.$data_environment.verygoodproxy.$tld;
       proxy_set_header        Via terminator;
       proxy_set_header        X-Forwarded-Host $host;
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header        VGS-Tenant $tenant;
       resolver                {{ ansible_dns.nameservers | join (',') }};
-      set                     $vault                                          https://reverse.$environment.verygoodproxy.$tld;
+      set                     $vault                                          https://reverse.$data_environment.verygoodproxy.$tld;
       proxy_pass              $vault;
       proxy_read_timeout      90;
     }
+
+    set $tenant_endpoint $tenant.$data_environment.verygoodproxy.$tld;
+    access_log /var/log/nginx/access.log json_combined;
 }
 
 server {
     listen              80 default_server;
-    server_name         _;    
+    server_name         _;
 
     rewrite ^/$ {{ cert_mgr_url }}/docs/http.html redirect;
 


### PR DESCRIPTION
By adding a prefix to the path of the certificate like this:
- `ssl/pt/tnt8ciq1xog.sandbox.verygoodproxy.io/tenant1c.testclients.verygoodsecurity.io` (Note the `pt/` path)

It is possible to control the `Host` header that is passed through to the vault reverse proxy application sitting behind this server.

By doing this we have more control over the route that will be selected and can use this information to offer multiple reverse proxies to our customers.

### Example
- `vault.sbx.customer-domain-a.com -> tenancy.verygoodproxy.com -> api.sbx.customer-domain-a.com`
- `vault.sbx.customer-domain-b.me -> tenancy.verygoodproxy.com -> api.sbx.customer-deomain-b.me`
 
Both host names are passed to the reverse proxy. Before this change is applied the reverse proxy app would receive `tenancy.verygoodproxy.com` as the host name and match on that to choose the route to send the traffic.

With this change enabled for a single tenant the proxy will receive the host name requested by the user e.g. `vault.sbx.customer-domain-a.com` and be able to route based on that.
